### PR TITLE
Fix asset name comparison

### DIFF
--- a/atacac/_utils.py
+++ b/atacac/_utils.py
@@ -13,6 +13,7 @@ import tower_cli
 from tower_cli.cli.transfer.send import Sender
 from tower_cli.cli.transfer.receive import Receiver
 from tower_cli.cli.transfer.common import SEND_ORDER as ASSET_TYPES
+import yaml
 
 
 LOG_COLORS = {
@@ -106,3 +107,13 @@ def tower_send(asset):
 
     sender = Sender(False)
     sender.send(source, None, None, 'default')
+
+
+def load_asset(file_path):
+    """
+    Load asset file to dict.
+
+    Now simply opens file and parses YAML.
+    """
+    with open(file_path) as f:
+        return yaml.safe_load(f)

--- a/atacac/backup.py
+++ b/atacac/backup.py
@@ -21,9 +21,8 @@ def main(label_id, destination):
         log('ERROR', f"Directory path: {destination}")
         log('ERROR', "Failed to create directory!", fatal=True)
 
-    job_templates_3SN = tower_list('job_template', [('labels', label_id)])
-
-    for jt in job_templates_3SN:
+    job_templates = tower_list('job_template', [('labels', label_id)])
+    for jt in job_templates:
         jt_name = jt['name']
         log('INFO', f"Downloading '{jt_name}' ...")
         jt_file = os.path.join(destination, jt_name.replace(' ', '_') + '.yml')

--- a/atacac/differentiate.py
+++ b/atacac/differentiate.py
@@ -13,7 +13,7 @@ from atacac._utils import log, tower_receive, load_asset
 def main(assets_glob):
     diff = False
 
-    for file_name in glob.glob(assets_glob, recursive=True):
+    for file_name in sorted(glob.glob(assets_glob, recursive=True)):
         asset = load_asset(file_name)
 
         try:

--- a/atacac/differentiate.py
+++ b/atacac/differentiate.py
@@ -30,9 +30,8 @@ def main(assets_glob):
             log('WARNING', (f"  Mismatch, '{file_name}' is not the same as "
                             f"the '{asset['name']}' in tower!"))
             log('INFO', "  Difference:")
-            for diff in differences:
-                for line in json.dumps(diff, indent=2).splitlines():
-                    log('INFO', f"    {line}")
+            for d in differences:
+                log('INFO', "    " + json.dumps(d, indent=2))
 
     if diff:
         log('ERROR', "Difference(s) found!", fatal=True)

--- a/atacac/differentiate.py
+++ b/atacac/differentiate.py
@@ -4,6 +4,7 @@ import glob
 import dictdiffer
 import click
 from tower_cli.exceptions import TowerCLIError
+import yaml
 
 from atacac._utils import log, tower_receive, load_asset
 
@@ -22,6 +23,11 @@ def main(assets_glob):
             log('INFO', (f"Asset '{asset['name']}' doesn't exist in Tower, no "
                          "need to check for diffs"))
             continue
+
+        # Need to parse extra vars to dict becuse in assets file it is YAML and
+        # in reponse from tower it is JSON.
+        asset['extra_vars'] = yaml.safe_load(asset['extra_vars'])
+        jt_data['extra_vars'] = yaml.safe_load(jt_data['extra_vars'])
 
         log('INFO', f"Differentiating '{file_name}' and '{asset['name']}'")
         differences = list(dictdiffer.diff(jt_data, asset))

--- a/atacac/synchronize.py
+++ b/atacac/synchronize.py
@@ -1,9 +1,8 @@
-import os
 import glob
 
 import click
 
-from atacac._utils import log, tower_list
+from atacac._utils import log, tower_list, load_asset
 
 
 @click.command()
@@ -11,10 +10,15 @@ from atacac._utils import log, tower_list
 @click.argument('assets_glob', envvar='ASSETS_GLOB')
 def main(label_id, assets_glob):
     # asset names in repository
-    local_assets = [
-        os.path.splitext(os.path.basename(file_name))[0].replace('_', ' ')
-        for file_name in glob.glob(assets_glob, recursive=True)
-    ]
+    local_assets = []
+    for file_name in glob.glob(assets_glob, recursive=True):
+        asset = load_asset(file_name)
+        # Can synchronize only assets of type job_template because we are
+        # getting assets from tower by label. Label is not available on projects
+        # or inventories.
+        if asset['asset_type'] != 'job_template':
+            continue
+        local_assets.append(asset['name'])
 
     # asset names in tower
     tower_assets = [

--- a/atacac/synchronize.py
+++ b/atacac/synchronize.py
@@ -11,7 +11,7 @@ from atacac._utils import log, tower_list, load_asset
 def main(label_id, assets_glob):
     # asset names in repository
     local_assets = []
-    for file_name in glob.glob(assets_glob, recursive=True):
+    for file_name in sorted(glob.glob(assets_glob, recursive=True)):
         asset = load_asset(file_name)
         # Can synchronize only assets of type job_template because we are
         # getting assets from tower by label. Label is not available on projects

--- a/atacac/upload.py
+++ b/atacac/upload.py
@@ -8,7 +8,7 @@ from atacac._utils import tower_send
 @click.command()
 @click.argument('assets_glob', envvar='ASSETS_GLOB')
 def main(assets_glob):
-    tower_send(glob.glob(assets_glob, recursive=True))
+    tower_send(sorted(glob.glob(assets_glob, recursive=True)))
 
 
 if __name__ == '__main__':

--- a/atacac/validate.py
+++ b/atacac/validate.py
@@ -18,7 +18,7 @@ def main(assets_glob, assets_schema, custom_validators):
         schema = yamale.make_schema(assets_schema,
                                     validators=validators.load(custom_validators))
 
-        for f in glob.glob(assets_glob, recursive=True):
+        for f in sorted(glob.glob(assets_glob, recursive=True)):
             log('INFO', f"Validating {f} against schema {assets_schema}")
             yamale.validate(schema, yamale.make_data(f))
 


### PR DESCRIPTION
Asset name was extracted from file name. Extracting name from asset data
is more robust and allows to name assets as user wants.